### PR TITLE
isuue-16: update グリーンリボンアート展の日時を更新

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -108,9 +108,9 @@
                             <p><b>会場</b>：東京都千代田区日比谷公園から東京都中央区鍛冶橋跡</p>
                         </li>
                         <li class="schedule__item">
-                            <p class="schedule__date">2022.<span class="ft-16">10.22-28</span></p>
+                            <p class="schedule__date">2022.<span class="ft-16">9.19-25</span></p>
                             <h4 class="ft-18 mb-10">グリーンリボンアート展</h4>
-                            <p><b>日時</b>：2022年10月22日～10月28日 <b>会場</b>：CLiP HIROSHIMA</p>
+                            <p><b>日時</b>：2022年9月19日(月)～9月25日(日) <b>会場</b>：CLiP HIROSHIMA</p>
                         </li>
                         <li class="schedule__item">
                             <p class="schedule__date">2022.<span class="ft-16">10.29</span></p>


### PR DESCRIPTION
![Screen Shot 2022-05-25 at 10 56 06](https://user-images.githubusercontent.com/92595/170162920-ccc66f2e-2ab7-4794-97c7-77090294bf15.png)

* その他確認した内容

- アート展で検索。該当箇所はここだけ。
