### PR TITLE
fix:(facebook) Facebook Page PluginがiOSで表示されないのを修正

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -37,7 +37,7 @@
 
 <body>
     <div id="fb-root"></div>
-    <script async defer crossorigin="anonymous" src="https://connect.facebook.net/ja_JP/sdk.js#xfbml=1&version=v10.0" nonce="7EKsihm0"></script>
+    <script async defer crossorigin="anonymous" src="https://connect.facebook.net/ja_JP/sdk.js#xfbml=1&version=v15.0&appId=230334520917413&autoLogAppEvents=1" nonce="nkScYNWH"></script>
     <header class="header">
         <div class="flexbox flex-justify-between flex-align-center container-l">
             <h1 class="logo"><a href="./"><img src="./img/common/logo.png" srcset="./img/common/logo@2x.png 2x" alt="NPO法人 グリーンリボン推進協会 Green Ribbon Promotion Association"></a></h1>
@@ -149,7 +149,8 @@
                 <div class="block--news">
                     <h3 class="mb-40"><img src="./img/top/hdg_news.png" srcset="./img/top/hdg_news@2x.png 2x" alt="ニュース"></h3>
                     <div class="fb__block animation-left">
-                        <div class="fb-page" data-href="https://www.facebook.com/greenribbonac/" data-tabs="timeline" data-width="500" data-height="500" data-small-header="true" data-adapt-container-width="true" data-hide-cover="false" data-show-facepile="true">
+                        <!-- dat-show-posts ではなく data-tabs="timeline" を使うのが最新だが、Safariで動作しないため旧形式を利用 -->
+                        <div class="fb-page" data-href="https://www.facebook.com/greenribbonac/" data-show-posts="true" data-width="500" data-height="500" data-small-header="true" data-adapt-container-width="true" data-hide-cover="false" data-show-facepile="true">
                             <blockquote cite="https://www.facebook.com/greenribbonac/" class="fb-xfbml-parse-ignore"><a href="https://www.facebook.com/greenribbonac/">NPO法人 グリーンリボン推進協会</a></blockquote>
                         </div>
                     </div>


### PR DESCRIPTION
iOSでFacebook Page Pluginが表示されない。調査した結果原因はわからないが、旧形式であるdata-show-postsをつかうと表示できるという話があったので変更している。

close #43 