### PR TITLE
活動スケジュールを広島支部と関東支部に分割

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -792,6 +792,30 @@ common parts
   text-decoration: underline;
 }
 
+.schedule__branch:not(:last-of-type){
+  margin-bottom: 45px;
+}
+
+.schedule__branch_hdg{
+  font-size: 2rem;
+  font-weight: bold;
+  color: #058A44;
+  border-left: 6px solid #009044;
+  padding-left: 14px;
+  margin-bottom: 20px;
+}
+
+.schedule__attention{
+  margin-top: 30px;
+  padding: 15px 20px;
+  font-size: 1.6rem;
+  font-weight: bold;
+  color: #009044;
+  background-color: #F4FBF4;
+  border-radius: 10px;
+  line-height: 1.8;
+}
+
 .bkg--white_dots{
   background: url(../img/common/bkg_dots_white.png) repeat top left;
     padding: 130px 0;

--- a/docs/index.html
+++ b/docs/index.html
@@ -90,28 +90,106 @@
             <div class="block--schedule">
               <h3 class="mb-40"><img src="./img/top/hdg_schedule.png" srcset="./img/top/hdg_schedule@2x.png 2x" alt="活動スケジュール"></h3>
 
-              <ul class="schedule__list animation-right">
-                <li class="schedule__item">
-                  <p class="schedule__date">2026.<span class="ft-16">9</span></p>
-                  <h4 class="ft-18 mb-10">メディア関係者向けワークショップ</h4>
-                  <p><b>日時</b>：詳細調整中</p>
-                  <p><b>会場</b>：東京都</p>
-                </li>
+              <div class="schedule__branch">
+                <h4 class="schedule__branch_hdg">広島支部</h4>
+                <ul class="schedule__list animation-right">
+                  <li class="schedule__item">
+                    <p class="schedule__date">2026.<span class="ft-16">9-10</span></p>
+                    <h5 class="ft-18 mb-10">移植を受けた子どもたちの絵画展</h5>
+                    <p><b>日時</b>：2026年9月21日(月)〜10月4日(日) 9:00〜17:00</p>
+                    <p><b>会場</b>：広島市南区民センター（さざなみギャラリー）</p>
+                  </li>
 
-                <li class="schedule__item">
-                  <p class="schedule__date">2026.<span class="ft-16">10.10</span></p>
-                  <h4 class="ft-18 mb-10">ひろしまグリーンリボンフェス</h4>
-                  <p><b>日時</b>：2026年10月10日(土)</p>
-                  <p><b>会場</b>：「エールエール」広島駅地下広場</p>
-                </li>
+                  <li class="schedule__item">
+                    <p class="schedule__date">2026.<span class="ft-16">10.3</span></p>
+                    <h5 class="ft-18 mb-10">ひろしまグリーンリボンパレード</h5>
+                    <p><b>日時</b>：2026年10月3日(土) 14:00〜</p>
+                    <p><b>会場</b>：広島本通商店街</p>
+                  </li>
 
-                <li class="schedule__item">
-                  <p class="schedule__date">2026.<span class="ft-16">10.25</span></p>
-                  <h4 class="ft-18 mb-10">グリーンリボンパレード</h4>
-                  <p><b>日時</b>：2026年10月25日(日)</p>
-                  <p><b>会場</b>：東京都渋谷駅周辺</p>
-                </li>
-              </ul>
+                  <li class="schedule__item">
+                    <p class="schedule__date">2026.<span class="ft-16">10.10</span></p>
+                    <h5 class="ft-18 mb-10">ひろしまグリーンリボンフェス</h5>
+                    <p><b>日時</b>：2026年10月10日(土)</p>
+                    <p><b>会場</b>：「エールエール」広島駅地下広場</p>
+                  </li>
+                </ul>
+              </div><!-- schedule branch 広島 -->
+
+              <div class="schedule__branch">
+                <h4 class="schedule__branch_hdg">関東支部</h4>
+                <ul class="schedule__list animation-right">
+                  <li class="schedule__item">
+                    <p class="schedule__date">2026.<span class="ft-16">4</span></p>
+                    <h5 class="ft-18 mb-10">移植医療啓発活動</h5>
+                    <p><b>日時</b>：2026年4月9日(木)10日(金) 10:00〜16:00(11:45〜12:45休憩)</p>
+                    <p><b>会場</b>：横浜市庁舎アトリウム</p>
+                  </li>
+
+                  <li class="schedule__item">
+                    <p class="schedule__date">2026.<span class="ft-16">5</span></p>
+                    <h5 class="ft-18 mb-10">移植医療啓発活動</h5>
+                    <p><b>日時</b>：2026年5月13日(水)14日(木) 10:00〜16:00(11:45〜12:45休憩)</p>
+                    <p><b>会場</b>：神奈川県庁</p>
+                  </li>
+
+                  <li class="schedule__item">
+                    <p class="schedule__date">2026.<span class="ft-16">7</span></p>
+                    <h5 class="ft-18 mb-10">移植医療啓発活動</h5>
+                    <p><b>日時</b>：2026年7月16日(木)17日(金) 10:00〜16:00(11:45〜12:45休憩)</p>
+                    <p><b>会場</b>：横浜市庁舎アトリウム</p>
+                  </li>
+
+                  <li class="schedule__item">
+                    <p class="schedule__date">2026.<span class="ft-16">8</span></p>
+                    <h5 class="ft-18 mb-10">移植医療啓発活動</h5>
+                    <p><b>日時</b>：2026年8月13日(木)14日(金) 10:00〜16:00(11:45〜12:45休憩)</p>
+                    <p><b>会場</b>：神奈川県庁</p>
+                  </li>
+
+                  <li class="schedule__item">
+                    <p class="schedule__date">2026.<span class="ft-16">9-12</span></p>
+                    <h5 class="ft-18 mb-10">メディア関係者向けワークショップ</h5>
+                    <p><b>日時</b>：詳細調整中</p>
+                    <p><b>会場</b>：東京都</p>
+                  </li>
+
+                  <li class="schedule__item">
+                    <p class="schedule__date">2026.<span class="ft-16">10.25</span></p>
+                    <h5 class="ft-18 mb-10">渋谷グリーンリボンパレード</h5>
+                    <p><b>日時</b>：2026年10月25日(日)</p>
+                    <p>11:30　集合　神宮通公園北側</p>
+                    <p>12:00〜13:00　パレード　東京都渋谷駅周辺</p>
+                    <p>13:00〜16:00　移植医療啓発イベント　神宮通公園</p>
+                  </li>
+
+                  <li class="schedule__item">
+                    <p class="schedule__date">2026.<span class="ft-16">10.29</span></p>
+                    <h5 class="ft-18 mb-10">移植医療啓発活動</h5>
+                    <p><b>日時</b>：2026年10月29日(木)30日(金) 10:00〜16:00(11:45〜12:45休憩)</p>
+                    <p><b>会場</b>：横浜市庁舎アトリウム</p>
+                  </li>
+
+                  <li class="schedule__item">
+                    <p class="schedule__date">2027.<span class="ft-16">1</span></p>
+                    <h5 class="ft-18 mb-10">移植医療啓発活動</h5>
+                    <p><b>日時</b>：2027年1月14日(木)15日(金) 10:00〜16:00(11:45〜12:45休憩)</p>
+                    <p><b>会場</b>：横浜市庁舎アトリウム</p>
+                  </li>
+
+                  <li class="schedule__item">
+                    <p class="schedule__date">2027.<span class="ft-16">3</span></p>
+                    <h5 class="ft-18 mb-10">厚生労働省要望書提出　記者会見</h5>
+                  </li>
+
+                  <li class="schedule__item">
+                    <p class="schedule__date">2027.<span class="ft-16">4</span></p>
+                    <h5 class="ft-18 mb-10">渋谷ヒカリエDeathフェス参加</h5>
+                  </li>
+                </ul>
+              </div><!-- schedule branch 関東 -->
+
+              <p class="schedule__attention">掲載イベント以外にも、皆様にご参加いただける企画を計画しております。</p>
             </div><!-- block schedule -->
 	  </div>
 	</section>


### PR DESCRIPTION
- 支部見出し（.schedule__branch_hdg）を追加し、広島支部・関東支部の スケジュールを分けて表示
- 日程範囲（絵画展）、複数行の予定（渋谷パレード）、会場や日時のない イベント（記者会見・Deathフェス）、詳細調整中などのパターンに対応
- 最後の案内文を強調表示（.schedule__attention）


Claude-Session: https://claude.ai/code/session_016Qpr5LVRFFrG9v6T4XV1Tf