### PR TITLE
2日間イベントの日付表記を範囲表記に統一

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -120,30 +120,30 @@
                 <h4 class="schedule__branch_hdg">関東支部</h4>
                 <ul class="schedule__list animation-right">
                   <li class="schedule__item">
-                    <p class="schedule__date">2026.<span class="ft-16">4</span></p>
+                    <p class="schedule__date">2026.<span class="ft-16">4.9-10</span></p>
                     <h5 class="ft-18 mb-10">移植医療啓発活動</h5>
-                    <p><b>日時</b>：2026年4月9日(木)10日(金) 10:00〜16:00(11:45〜12:45休憩)</p>
+                    <p><b>日時</b>：2026年4月9日(木)〜10日(金) 10:00〜16:00(11:45〜12:45休憩)</p>
                     <p><b>会場</b>：横浜市庁舎アトリウム</p>
                   </li>
 
                   <li class="schedule__item">
-                    <p class="schedule__date">2026.<span class="ft-16">5</span></p>
+                    <p class="schedule__date">2026.<span class="ft-16">5.13-14</span></p>
                     <h5 class="ft-18 mb-10">移植医療啓発活動</h5>
-                    <p><b>日時</b>：2026年5月13日(水)14日(木) 10:00〜16:00(11:45〜12:45休憩)</p>
+                    <p><b>日時</b>：2026年5月13日(水)〜14日(木) 10:00〜16:00(11:45〜12:45休憩)</p>
                     <p><b>会場</b>：神奈川県庁</p>
                   </li>
 
                   <li class="schedule__item">
-                    <p class="schedule__date">2026.<span class="ft-16">7</span></p>
+                    <p class="schedule__date">2026.<span class="ft-16">7.16-17</span></p>
                     <h5 class="ft-18 mb-10">移植医療啓発活動</h5>
-                    <p><b>日時</b>：2026年7月16日(木)17日(金) 10:00〜16:00(11:45〜12:45休憩)</p>
+                    <p><b>日時</b>：2026年7月16日(木)〜17日(金) 10:00〜16:00(11:45〜12:45休憩)</p>
                     <p><b>会場</b>：横浜市庁舎アトリウム</p>
                   </li>
 
                   <li class="schedule__item">
-                    <p class="schedule__date">2026.<span class="ft-16">8</span></p>
+                    <p class="schedule__date">2026.<span class="ft-16">8.13-14</span></p>
                     <h5 class="ft-18 mb-10">移植医療啓発活動</h5>
-                    <p><b>日時</b>：2026年8月13日(木)14日(金) 10:00〜16:00(11:45〜12:45休憩)</p>
+                    <p><b>日時</b>：2026年8月13日(木)〜14日(金) 10:00〜16:00(11:45〜12:45休憩)</p>
                     <p><b>会場</b>：神奈川県庁</p>
                   </li>
 
@@ -165,16 +165,16 @@
                   </li>
 
                   <li class="schedule__item">
-                    <p class="schedule__date">2026.<span class="ft-16">10.29</span></p>
+                    <p class="schedule__date">2026.<span class="ft-16">10.29-30</span></p>
                     <h5 class="ft-18 mb-10">移植医療啓発活動</h5>
-                    <p><b>日時</b>：2026年10月29日(木)30日(金) 10:00〜16:00(11:45〜12:45休憩)</p>
+                    <p><b>日時</b>：2026年10月29日(木)〜30日(金) 10:00〜16:00(11:45〜12:45休憩)</p>
                     <p><b>会場</b>：横浜市庁舎アトリウム</p>
                   </li>
 
                   <li class="schedule__item">
-                    <p class="schedule__date">2027.<span class="ft-16">1</span></p>
+                    <p class="schedule__date">2027.<span class="ft-16">1.14-15</span></p>
                     <h5 class="ft-18 mb-10">移植医療啓発活動</h5>
-                    <p><b>日時</b>：2027年1月14日(木)15日(金) 10:00〜16:00(11:45〜12:45休憩)</p>
+                    <p><b>日時</b>：2027年1月14日(木)〜15日(金) 10:00〜16:00(11:45〜12:45休憩)</p>
                     <p><b>会場</b>：横浜市庁舎アトリウム</p>
                   </li>
 


### PR DESCRIPTION
## 概要

関東支部の2日間イベント「移植医療啓発活動」の日付表記が、他の期間イベントと不揃いだったため統一しました。

## 背景

- これらの2日間イベントは `672e561`（活動スケジュールを広島支部と関東支部に分割）で新規追加されて以降、`9日(木)10日(金)` のように区切りなしで2つの日付が連結表示されていました。
- 一方、同じページの絵画展（複数日）は `9月21日(月)〜10月4日(日)` と `〜` を使った範囲表記になっており、ページ内で表記が混在していました。
- また `.schedule__date` は通例 `年.月.日`（開催日まで表示）ですが、これらのイベントだけ月のみ（例 `2026.4`）で通例から外れていました。

## 変更内容

対象6件（4月・5月・7月・8月・10月・翌1月）について:

| 項目 | 変更前 | 変更後 |
|---|---|---|
| 日時 | `2026年4月9日(木)10日(金)` | `2026年4月9日(木)〜10日(金)` |
| `.schedule__date` | `2026.4` | `2026.4.9-10` |

- 日時を範囲表記（`〜`）に統一
- `.schedule__date` を通例の `年.月.日` に合わせ、開催日をハイフンのレンジで表示（10月分は `10.29` → `10.29-30`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013AWdiQTohHmybG5ZTK59GA)_